### PR TITLE
Fix typo in example

### DIFF
--- a/docs/react/README.md
+++ b/docs/react/README.md
@@ -41,7 +41,7 @@ export default class extends React.Component {
   render() {
     return (
       <div>
-        You have {this.props.message.length} new messages.
+        You have {this.props.messages.length} new messages.
       </div>
     )
   }


### PR DESCRIPTION
Just noticed while reading, fairly trivial and doesn't lower the ease of understanding.