### PR TITLE
Add support for scoped dependencies

### DIFF
--- a/packages/dep-tree-js/index.js
+++ b/packages/dep-tree-js/index.js
@@ -46,8 +46,10 @@ function getPackages(file){
     var imports = konan(file, fs.readFileSync(file, 'utf8'))
     // only strings for now.
     imports.strings.forEach((imp)=> {
-      // trim submodule imports and install main package (ie. 'bootstrap' for: import 'bootstrap/dist/css/bootstrap.min.css')
-      imp = imp.split("/")[0]
+      // trim submodule imports and install main package (ie. 'bootstrap' for: import 'bootstrap/dist/css/bootstrap.min.css') - except scoped package names
+      if (!imp.startsWith("@")) {
+        imp = imp.split("/")[0]
+      }
       // skip relative imports and built-in imports (on newer node versions only)
       if (!imp.startsWith(".") && builtInPackages.indexOf(imp)===-1) {
         deps.push(imp)

--- a/packages/dep-tree-js/index.js
+++ b/packages/dep-tree-js/index.js
@@ -46,10 +46,7 @@ function getPackages(file){
     var imports = konan(file, fs.readFileSync(file, 'utf8'))
     // only strings for now.
     imports.strings.forEach((imp)=> {
-      // trim submodule imports and install main package (ie. 'bootstrap' for: import 'bootstrap/dist/css/bootstrap.min.css') - except scoped package names
-      if (!imp.startsWith("@")) {
-        imp = imp.split("/")[0]
-      }
+      imp = trimPackageName(imp);
       // skip relative imports and built-in imports (on newer node versions only)
       if (!imp.startsWith(".") && builtInPackages.indexOf(imp)===-1) {
         deps.push(imp)
@@ -58,6 +55,14 @@ function getPackages(file){
   }
 
   return deps
+}
+
+// trim submodule imports to only install main package (ie. 'bootstrap' for: import 'bootstrap/dist/css/bootstrap.min.css')
+// scoped package names are allowed to have one / - after that they will be trimmed as well
+function trimPackageName(dep) {
+  const regex =  /(@[^\/]*\/[^\/]*)?(^([^@][^\/]*)\/?)?/
+  var matches = dep.match(regex);
+  return matches[1] || matches[3];
 }
 
 module.exports = {


### PR DESCRIPTION
This is a fix to allow [scoped packages](https://docs.npmjs.com/misc/scope) to be included as dependencies in a zero project. A scoped package name will always start with an `@` and must include a `/`, so we can be reasonably be sure that if it starts with `@` we should not split it.