### PR TITLE
Fix: zero exposing package-lock.json & node_modules by default

### DIFF
--- a/packages/core/lib/utils/zeroignore.js
+++ b/packages/core/lib/utils/zeroignore.js
@@ -15,6 +15,7 @@ const fs = require("fs");
 const DEFAULTIGNORES = [
   "_*",
   ".*",
+  "node_modules/*",
   "package.json",
   "package-lock.json",
   "Dockerfile",

--- a/packages/core/lib/utils/zeroignore.js
+++ b/packages/core/lib/utils/zeroignore.js
@@ -1,4 +1,4 @@
-/* 
+/*
 a wrapper around node-ignore with default ignores added.
 zeroignore works on file-level and restricts exposing ignored files
 from becoming lambdas/handlers or even static public files.
@@ -16,6 +16,7 @@ const DEFAULTIGNORES = [
   "_*",
   ".*",
   "package.json",
+  "package-lock.json",
   "Dockerfile",
   "zero-deploy"
 ];


### PR DESCRIPTION
zero already ignores package.json by default, but not package-lock.json.
`localhost:3000/package-lock.json` -> can be accessed

also, files inside node_modules can be accessed at the moment. 
`localhost:3000/node_modules/@types/node/README.md`

this pull request adds these two things to the existing default ignores