### PR TITLE
Bumping TypeScript version to 3.6.4 (Currently latest stable version)

### DIFF
--- a/packages/common-deps/package.json
+++ b/packages/common-deps/package.json
@@ -22,7 +22,7 @@
     "react-hot-loader": "^4.12.12",
     "regenerator-runtime": "^0.12.0",
     "sass": "^1.17.2",
-    "typescript": "^3.3.3333",
+    "typescript": "^3.6.4",
     "vue": "^2.6.10",
     "vue-hot-reload-api": "^2.3.3",
     "vue-meta": "^1.6.0",

--- a/packages/dep-tree-js/package.json
+++ b/packages/dep-tree-js/package.json
@@ -7,7 +7,7 @@
     "@mdx-js/mdx": "^0.16.8",
     "@vue/component-compiler-utils": "^2.6.0",
     "konan": "^1.2.1",
-    "typescript": "3.3.3333",
+    "typescript": "^3.6.4",
     "vue-template-compiler": "^2.6.10"
   }
 }


### PR DESCRIPTION
#82 

NOTE: It is also possible to change it to "latest" but since its the latest stable version I think it's better to leave it at 3.6.4 for now.